### PR TITLE
Remove hardcoded path from DiscussionsController

### DIFF
--- a/app/controllers/DiscussionsController.php
+++ b/app/controllers/DiscussionsController.php
@@ -956,7 +956,7 @@ class DiscussionsController extends Controller
         $this->tag->setAutoEscape(false);
 
         $this->view->user      = $user;
-        $this->view->timezones = APP_PATH .'/app/config/timezones.php';
+        $this->view->timezones = require APP_PATH .'/app/config/timezones.php';
 
         $parametersNumberPosts   = array(
             'users_id = ?0 AND deleted = 0',


### PR DESCRIPTION
For already deployed apps this should be better than adding a new entry to config.php:

```
    'application' => array(
        'configDir' => APP_PATH . '/app/config/',
```

still an alternative though.
