### PR TITLE
Modified the Regex

### DIFF
--- a/app/library/Markdown/BlockQuoteExtension.php
+++ b/app/library/Markdown/BlockQuoteExtension.php
@@ -44,7 +44,7 @@ class BlockQuoteExtension implements ExtensionInterface, RendererAwareInterface
     public function processBlockQuote(Text $text)
     {
         $text->replace(
-            '{
+            '/{
             (?:
             (?:
               ^[ \t]*&gt;[ \t]? # \'>\' at the start of a line
@@ -54,7 +54,7 @@ class BlockQuoteExtension implements ExtensionInterface, RendererAwareInterface
             )+
             )
             }
-            mx',
+            /mx',
             function (Text $bq) {
                 $bq->replace('/^[ \t]*&gt;[ \t]?/m', '');
                 $bq->replace('/^[ \t]+$/m', '');


### PR DESCRIPTION
This modification fixed an error being caused due to the `ciconia` library. Not sure if this is an issue in phosphorum or ciconia. The error was as follows:

>Warning: preg_replace_callback(): Unknown modifier ' ' in F:\xampp\htdocs\test.loc\phosphorum\forum\vendor\kzykhys\ciconia\src\Ciconia\Common\Text.php on line 177  
>Call Stack  
>Time Memory	Function	Location   
>0.2120	1511680	Phosphorum\Markdown\BlockQuoteExtension->processBlockQuote( )\EmitterTrait.php:64  
>0.2120	1512256	Ciconia\Common\Text->replace( )	..\BlockQuoteExtension.php:70  
>0.2120	1512800	preg_replace_callback ( )	..\Text.php:177