### PR TITLE
Re-order code highlighting examples

### DIFF
--- a/app/views/help/markdown.volt
+++ b/app/views/help/markdown.volt
@@ -101,12 +101,14 @@ Nulla neque nisl, fringilla sed blandit non, pretium eu odio.
 		<h3>Code Blocks</h3>
 	</p>
 
+**Preferred method**
 <p>
 <pre>
-Lorem ipsum dolor sit amet
+```php
+&lt;?php
 
-    consectetur adipiscing elit.
-    Nulla neque nisl, fringilla sed blandit non, pretium eu odio.
+require __DIR__ . '/vendor/autoload.php';
+```
 </pre>
 </p>
 
@@ -121,13 +123,15 @@ $ sudo ./install
 
 <p>
 <pre>
-```php
-&lt;?php
+Lorem ipsum dolor sit amet
 
-require __DIR__ . '/vendor/autoload.php';
-```
+    consectetur adipiscing elit.
+    Nulla neque nisl, fringilla sed blandit non, pretium eu odio.
 </pre>
 </p>
+
+
+
 
 <p>
 	<h3>Inline Code</h3>


### PR DESCRIPTION
Relatively few people use the proper syntax highlighting tags.  This may be due to the fact they see the indentation example, then quit reading.  Re-ordering the examples may increase the number of people using the best tags.
