### PR TITLE
The search dropdown now makes use of Bootstrap's input-group component

### DIFF
--- a/app/views/partials/top-menu.volt
+++ b/app/views/partials/top-menu.volt
@@ -24,12 +24,10 @@
 					<li>
 						<div style="width:300px;padding: 20px">
 							{{ form('search', 'method': 'get', 'autocomplete': 'off') }}
-								<table width="100%">
-									<tr>
-										<td><input type="text" class="form-control" name="q"></td>
-										<td>&nbsp;<input type="submit" class="btn btn-primary" value="Search"></td>
-									</tr>
-								</table>
+								<div class="input-group">
+									<input type="text" class="form-control" name="q">
+									<span class="input-group-btn"><input type="submit" class="btn btn-primary" value="Search"></span>
+								</div>
 							</form>
 							<!--<gcse:searchbox-only></gcse:searchbox-only>-->
 						</div>


### PR DESCRIPTION
The search dropdown now makes use of [Bootstrap's input-group component](http://getbootstrap.com/components/#input-groups).

Here's a before and after (in Chrome): http://imgur.com/ufRCbyf