### PR TITLE
Fixed #85 issue

### DIFF
--- a/app/config/services.php
+++ b/app/config/services.php
@@ -307,6 +307,7 @@ $di->set(
     'markdown',
     function () {
         $ciconia = new Ciconia();
+        $ciconia->addExtension(new \Phosphorum\Markdown\UnderscoredUrlsExtension());
         $ciconia->addExtension(new \Phosphorum\Markdown\TableExtension());
         $ciconia->addExtension(new \Phosphorum\Markdown\MentionExtension());
         $ciconia->addExtension(new \Phosphorum\Markdown\BlockQuoteExtension());

--- a/app/controllers/DiscussionsController.php
+++ b/app/controllers/DiscussionsController.php
@@ -545,7 +545,6 @@ class DiscussionsController extends ControllerBase
         }
 
         if (!$this->request->isPost()) {
-
             // Find the post using get
             $post = Posts::findFirstById($id);
             if (!$post) {
@@ -569,7 +568,6 @@ class DiscussionsController extends ControllerBase
 
             // A view is stored by ip address
             if (!$viewed) {
-
                 // Increase the number of views in the post
                 $post->number_views++;
                 if ($post->users_id != $usersId) {
@@ -577,8 +575,6 @@ class DiscussionsController extends ControllerBase
                     $post->user->increaseKarma(Karma::VISIT_ON_MY_POST);
 
                     if ($usersId > 0) {
-
-                        /** @var Users $user */
                         $user = Users::findFirstById($usersId);
                         if ($user) {
                             if ($user->moderator == 'Y') {
@@ -586,6 +582,7 @@ class DiscussionsController extends ControllerBase
                             } else {
                                 $user->increaseKarma(Karma::VISIT_POST);
                             }
+
                             $user->save();
                         }
                     }

--- a/app/controllers/DiscussionsController.php
+++ b/app/controllers/DiscussionsController.php
@@ -524,8 +524,8 @@ class DiscussionsController extends ControllerBase
     /**
      * Displays a post and its comments
      *
-     * @param $id
-     * @param $slug
+     * @param int $id Post ID
+     * @param string $slug Post slug
      *
      * @return \Phalcon\Http\ResponseInterface
      */
@@ -533,27 +533,20 @@ class DiscussionsController extends ControllerBase
     {
         $id = (int)$id;
 
-        $usersId = $this->session->get('identity');
-
         // Check read / unread topic
-
-        if ($usersId !='') {
+        if ($usersId = $this->session->get('identity')) {
             $check_topic = new TopicTracking();
             $check_topic->user_id = $usersId;
             $check_topic->topic_id = $id;
+
             if ($check_topic->create() == false) {
-                $sql     = "UPDATE topic_tracking SET topic_id=IF(topic_id='',{$id}, CONCAT(topic_id,',{$id}')) WHERE user_id=:user_id AND NOT (FIND_IN_SET('{$id}', topic_id) OR FIND_IN_SET(' {$id}', topic_id));";
-                $this->db->query($sql, array("user_id" => $usersId));
-            } else {
+                $check_topic->updateTracking($id, $usersId);
             }
         }
 
-
         if (!$this->request->isPost()) {
 
-            /**
-             * Find the post using get
-             */
+            // Find the post using get
             $post = Posts::findFirstById($id);
             if (!$post) {
                 $this->flashSession->error('The discussion does not exist');
@@ -567,20 +560,17 @@ class DiscussionsController extends ControllerBase
 
             $ipAddress = $this->request->getClientAddress();
 
-            $parameters = array(
+            $parameters = [
                 'posts_id = ?0 AND ipaddress = ?1',
-                'bind' => array($id, $ipAddress)
-            );
+                'bind' => [$id, $ipAddress]
+            ];
+
             $viewed = PostsViews::count($parameters);
 
-            /**
-             * A view is stored by ipaddress
-             */
+            // A view is stored by ip address
             if (!$viewed) {
 
-                /**
-                 * Increase the number of views in the post
-                 */
+                // Increase the number of views in the post
                 $post->number_views++;
                 if ($post->users_id != $usersId) {
 
@@ -612,28 +602,21 @@ class DiscussionsController extends ControllerBase
             }
 
             if (!$usersId) {
+                // Enable cache
+                $this->view->cache(['key' => 'post-' . $id]);
 
-                /**
-                 * Enable cache
-                 */
-                $this->view->cache(array('key' => 'post-' . $id));
-
-                /**
-                 * Check for a cache
-                 */
+                // Check for a cache
                 if ($this->viewCache->exists('post-' . $id)) {
                     return;
                 }
             }
 
-            /**
-             * Generate cannonical meta
-             */
-            $this->view->canonical = 'discussion/' . $post->id . '/' . $post->slug;
-            $this->view->author    = $post->user;
-
+            // Generate canonical meta
+            $this->view->setVars([
+                'canonical' => 'discussion/' . $post->id . '/' . $post->slug,
+                'author'    => $post->user
+            ]);
         } else {
-
             if (!$this->checkTokenPost()) {
                 return $this->response->redirect();
             }
@@ -643,9 +626,7 @@ class DiscussionsController extends ControllerBase
                 return $this->response->redirect();
             }
 
-            /**
-             * Find the post using POST
-             */
+            // Find the post using POST
             $post = Posts::findFirstById($this->request->getPost('id'));
             if (!$post) {
                 $this->flashSession->error('The discussion does not exist');
@@ -660,9 +641,7 @@ class DiscussionsController extends ControllerBase
             $content = $this->request->getPost('content', 'trim');
             if ($content) {
 
-                /**
-                 * Check if the question can have a bounty before add the reply
-                 */
+                // Check if the question can have a bounty before add the reply
                 $canHaveBounty = $post->canHaveBounty();
 
                 $user = Users::findFirstById($usersId);
@@ -671,9 +650,7 @@ class DiscussionsController extends ControllerBase
                     return $this->response->redirect();
                 }
 
-                /**
-                 * Only update the number of replies if the user that commented isn't the same that posted
-                 */
+                // Only update the number of replies if the user that commented isn't the same that posted
                 if ($post->users_id != $usersId) {
 
                     $post->number_replies++;
@@ -721,7 +698,7 @@ class DiscussionsController extends ControllerBase
          */
         $this->tag->setTitle($this->escaper->escapeHtml($post->title) . ' - Discussion');
 
-        $this->view->post = $post;
+        $this->view->setVar('post', $post);
     }
 
     /**

--- a/app/library/Markdown/UnderscoredUrlsExtension.php
+++ b/app/library/Markdown/UnderscoredUrlsExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Phosphorum\Markdown;
+
+use Ciconia\Common\Text;
+use Ciconia\Extension\ExtensionInterface;
+use Ciconia\Markdown;
+
+/**
+ * Underscored URLs Extension
+ *
+ * @package Phosphorum\Markdown
+ */
+class UnderscoredUrlsExtension implements ExtensionInterface
+{
+    public function register(Markdown $markdown)
+    {
+        $markdown->on('inline', [$this, 'processTest']);
+    }
+
+    public function processTest(Text $text)
+    {
+        $hashes = [];
+
+        // escape <code>
+        $text->replace('{<code>.*?</code>}m', function (Text $w) use (&$hashes) {
+            $md5 = md5($w);
+            $hashes[$md5] = $w;
+
+            return "{gfm-extraction-$md5}";
+        });
+
+        $text->replace('#(?:(?<=[href|src]=\"|\')(?:[a-z0-9]+:\/\/)?|(?:[a-z0-9]+:\/\/))([^\'">\s]+_+[^\'">\s]*)+#i', function (Text $w) {
+
+            $w->replaceString('_', '%5');
+
+            return $w;
+        });
+
+        /** @noinspection PhpUnusedParameterInspection */
+        $text->replace('/\{gfm-extraction-([0-9a-f]{32})\}/m', function (Text $w, Text $md5) use (&$hashes) {
+            return $hashes[(string)$md5];
+        });
+    }
+
+    public function getName()
+    {
+        return 'underscoredUrls';
+    }
+}

--- a/app/models/Posts.php
+++ b/app/models/Posts.php
@@ -27,7 +27,7 @@ use Phalcon\Mvc\Model;
  * @property \Phosphorum\Models\PostsReplies[] replies
  * @property \Phosphorum\Models\PostsViews[]   views
  *
- * @method static Posts findFirstById
+ * @method static Posts findFirstById(int $id)
  * @method static Posts findFirst($parameters = null)
  * @method static Posts[] find($parameters = null)
  * @method PostsReplies[] getReplies

--- a/app/models/TopicTracking.php
+++ b/app/models/TopicTracking.php
@@ -41,4 +41,16 @@ class TopicTracking extends Model
     {
         $this->setSource('topic_tracking');
     }
+
+    public function updateTracking($postId, $userId)
+    {
+        $sql = "
+            UPDATE topic_tracking
+            SET topic_id=IF(topic_id='',{$postId}, CONCAT(topic_id,',{$postId}'))
+            WHERE user_id=:user_id
+            AND NOT (FIND_IN_SET('{$postId}', topic_id) OR FIND_IN_SET(' {$postId}', topic_id))
+        ";
+
+        return $this->getReadConnection()->query($sql, ['user_id' => $userId]);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "aws/aws-sdk-php": "~2.5",
         "guzzle/guzzle": ">=4.0|<7.0",
         "swiftmailer/swiftmailer": "~5.4",
-        "kzykhys/ciconia": "~1.0.0",
+        "kzykhys/ciconia": "~1.0",
         "phpspec/php-diff": "~1.0",
         "elasticsearch/elasticsearch": "~1.0",
         "dropbox/dropbox-sdk": "1.1.*"

--- a/tests/functional/CorrectConvertUrlCept.php
+++ b/tests/functional/CorrectConvertUrlCept.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Test for https://github.com/phalcon/forum/issues/85 issue
+ *
+ * @var \Codeception\Scenario $scenario
+ */
+
+$I = new Step\Functional\UserSteps($scenario);
+
+$I->wantTo('use underscored character in content and see correct url');
+
+$userId = $I->amRegularUser();
+
+$catId = $I->haveCategory([
+    'name' => 'Installation',
+    'slug' => 'installation',
+    'description' => 'Installation related posts'
+]);
+
+$postId = $I->havePost([
+    'title' => 'Is there a precompiled binary for 64 bit Centos out there',
+    'content' => '[this reddit topic](http://www.reddit.com/r/PHP/comments/2s7bbr/phalconphp_vs_php_disappointing_results/)',
+    'users_id' => 1,
+    'slug' => 'is-there-a-precompiled-binary-for-64-bit-centos-out-there',
+    'categories_id' => $catId
+]);
+
+
+$I->amOnPage('/discussions');
+$I->seeInTitle('Discussions - Phalcon Framework');
+$I->seeLink('Is there a precompiled binary for 64 bit Centos out there');
+$I->click('Is there a precompiled binary for 64 bit Centos out there');
+$I->seeInCurrentUrl(sprintf('/discussion/%s/is-there-a-precompiled-binary-for-64-bit-centos-out-there', $postId));
+$I->seeLink('this reddit topic', 'http://www.reddit.com/r/PHP/comments/2s7bbr/phalconphp%5vs%5php%5disappointing%5results/');


### PR DESCRIPTION
In accordance with [rfc1738][1]:

> Thus, only alphanumerics, the special characters "$-_.+!\*'(),",
> and reserved characters used for their reserved purposes **may be used** unencoded within a URL.

**may be** used, but not **must be** used unencoded.

I decoded `_` to safe equivalent `%5`.
For more detail see: https://github.com/kzykhys/Ciconia/issues/42

[1]: http://www.rfc-editor.org/rfc/rfc1738.txt