### PR TITLE
Fixed Security::checkPrefixedToken

### DIFF
--- a/app/library/Utils/Security.php
+++ b/app/library/Utils/Security.php
@@ -118,13 +118,13 @@ class Security extends PhSecurity
             $tokenValue = $request->getPost($tokenKey);
         }
 
-        $returnValue = ($tokenValue == $session->get($prefixedValue));
+        $equals = hash_equals($session->get($prefixedValue), $tokenValue);
 
-        if ($returnValue && $destroyIfValid) {
+        if ($equals && $destroyIfValid) {
             $this->destroyPrefixedToken($prefix);
         }
 
-        return $returnValue;
+        return $equals;
     }
 
     /**


### PR DESCRIPTION
Fixed `Phosphorum\Utils\Security::checkPrefixedToken` to prevent possible timing
attack.