### PR TITLE
/github/oauth/access_token is not a valid route the system uses /login/oauth/access_token/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ MANDRILL_SECRET=
 
 GITHUB_CLIENT_ID=
 GITHUB_SECRET=
-GITHUB_REDIRECT_URI=http://pforum.loc/oauth/github/access_token
+GITHUB_REDIRECT_URI=http://pforum.loc/login/oauth/access_token/
 
 DROPBOX_TOKEN=
 DROPBOX_SECRET=


### PR DESCRIPTION
### What am I?
A trivial change to the `.env.example` so the default matches the expected route for the system to reduce confusion when configuring the `callback_url` with github