### PR TITLE
Fixed value Adding a reply on someone elses post in Karma.php

### DIFF
--- a/app/model/Karma.php
+++ b/app/model/Karma.php
@@ -32,7 +32,7 @@ abstract class Karma
 
     const SOMEONE_REPLIED_TO_MY_POST = 5;
 
-    const REPLY_ON_SOMEONE_ELSE_POST = 10;
+    const REPLY_ON_SOMEONE_ELSE_POST = 15;
 
     const SOMEONE_DELETED_HIS_OR_HER_REPLY_ON_MY_POST = 5;
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #86

**In raising this pull request, I confirm the following:**

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Changed `Adding a reply on someone else's post` to 15 in `app/model/Karma.php`. In description of reputation on forum this value is 15.

Thanks