### PR TITLE
Changed counting karma when post was deleting

### DIFF
--- a/app/controller/DiscussionsController.php
+++ b/app/controller/DiscussionsController.php
@@ -453,11 +453,11 @@ class DiscussionsController extends ControllerBase
                         $user->save();
                     }
                 }
-
-                $user = $post->user;
-                $user->decreaseKarma(Karma::DELETE_POST);
-                $user->save();
             }
+
+            $user = $post->user;
+            $user->decreaseKarma(Karma::DELETE_POST);
+            $user->save();
 
             $this->flashSession->success('Discussion was successfully deleted');
             return $this->response->redirect();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #86

**In raising this pull request, I confirm the following:**

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
`app/controller/DiscussionsController.php` - changed counting reputation when post was deleting. When user deleted own post, his reputations wasn't changing. Decrease karma started when ID user's post don't equal ID current user.

Thanks