### PR TITLE
Changed decrease reputation when someone deleted own reply

### DIFF
--- a/app/controller/RepliesController.php
+++ b/app/controller/RepliesController.php
@@ -174,11 +174,6 @@ class RepliesController extends ControllerBase
 
             if ($postReply->delete()) {
                 if ($usersId != $postReply->post->users_id) {
-                    $user = $postReply->post->user;
-                    if ($user) {
-                        $user->decreaseKarma(Karma::SOMEONE_DELETED_HIS_OR_HER_REPLY_ON_MY_POST);
-                        $user->save();
-                    }
                     $postReply->post->number_replies--;
                     $postReply->post->save();
                 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #86

**In raising this pull request, I confirm the following:**

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
When someone was deleting own reply, post's owner karma decreased. Activity list on forum doesn't have any notification users about it.

Thanks