### PR TITLE
Changed count reputation when reply is accept answer

### DIFF
--- a/app/controller/RepliesController.php
+++ b/app/controller/RepliesController.php
@@ -544,7 +544,8 @@ class RepliesController extends ControllerBase
             $postReply->post->user->karma += Karma::SOMEONE_ELSE_ACCEPT_YOUR_REPLY;
             $postReply->post->user->votes_points += Karma::SOMEONE_ELSE_ACCEPT_YOUR_REPLY;
 
-            $points = (30 + intval(abs($user->karma - $postReply->user->karma) / 1000));
+            $points = (Karma::SOMEONE_ELSE_ACCEPT_YOUR_REPLY
+                + intval(abs($user->karma - $postReply->user->karma) / 1000));
 
             $parametersBounty = [
                 'users_id = ?0 AND posts_replies_id = ?1',


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #86

**In raising this pull request, I confirm the following:**

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Changed added reputation point when reply is 'accepted answer'. The forum's activity list has `Getting an own reply as 'accepted answer' by someone else` = `50 + abs(user_karma - your_karma) / 1000`.

Thanks