### PR TITLE
Fix spec symbol in post

### DIFF
--- a/app/provider/Markdown/Plugins/SpecSymbolExtension.php
+++ b/app/provider/Markdown/Plugins/SpecSymbolExtension.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+   +------------------------------------------------------------------------+
+   | Phalcon forum                                                          |
+   +------------------------------------------------------------------------+
+   | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+   +------------------------------------------------------------------------+
+   | This source file is subject to the New BSD License that is bundled     |
+   | with this package in the file LICENSE.txt.                             |
+   |                                                                        |
+   | If you did not receive a copy of the license and are unable to         |
+   | obtain it through the world-wide-web, please send an email             |
+   | to license@phalconphp.com so we can send you a copy immediately.       |
+   +------------------------------------------------------------------------+
+   | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+   +------------------------------------------------------------------------+
+ */
+
+namespace Phosphorum\Provider\Markdown\Plugins;
+
+use Ciconia\Markdown;
+use Ciconia\Common\Text;
+use Ciconia\Extension\ExtensionInterface;
+
+class SpecSymbolExtension implements ExtensionInterface
+{
+    public function register(Markdown $markdown)
+    {
+        $markdown->on('inline', [$this, 'escapeText']);
+    }
+
+    public function escapeText(Text $text)
+    {
+        $replaceArray = [];
+
+        $text->replace('{<code>.*?</code>}m', function (Text $w) use (&$replaceArray) {
+            $count = count($replaceArray) + 1;
+            $replaceArray[$count] = $w->getString();
+            $w->replaceString($w->getString(), "%%replaced" . $count . "%%");
+
+            return $w;
+        });
+
+        $str = htmlspecialchars($text->getString());
+        foreach ($replaceArray as $key => $value) {
+            $str = str_replace("%%replaced" . $key . "%%", $value, $str);
+        }
+
+        $text->setString($str);
+    }
+
+    public function getName()
+    {
+        return 'escapeText';
+    }
+}

--- a/app/provider/Markdown/ServiceProvider.php
+++ b/app/provider/Markdown/ServiceProvider.php
@@ -52,6 +52,7 @@ class ServiceProvider extends AbstractServiceProvider
                 $ciconia->addExtension(new Plugins\BlockQuoteExtension());
                 $ciconia->addExtension(new Plugins\UrlAutoLinkExtension());
                 $ciconia->addExtension(new FencedCodeBlockExtension());
+                $ciconia->addExtension(new Plugins\SpecSymbolExtension());
 
                 return $ciconia;
             }

--- a/app/views/discussions/view.volt
+++ b/app/views/discussions/view.volt
@@ -43,7 +43,7 @@
                 <div class="post-content">
                     {%- cache "post-body-" ~ post.id -%}
                         <div>
-                            {{- markdown.render(post.content|e) -}}
+                            {{- markdown.render(post.content) -}}
                         </div>
                     {%- endcache -%}
 

--- a/tests/acceptance/SpecialSymbolTestCest.php
+++ b/tests/acceptance/SpecialSymbolTestCest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+   +------------------------------------------------------------------------+
+   | Phalcon forum                                                          |
+   +------------------------------------------------------------------------+
+   | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+   +------------------------------------------------------------------------+
+   | This source file is subject to the New BSD License that is bundled     |
+   | with this package in the file LICENSE.txt.                             |
+   |                                                                        |
+   | If you did not receive a copy of the license and are unable to         |
+   | obtain it through the world-wide-web, please send an email             |
+   | to license@phalconphp.com so we can send you a copy immediately.       |
+   +------------------------------------------------------------------------+
+   | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+   +------------------------------------------------------------------------+
+ */
+
+use Helper\Post;
+use Helper\User;
+use Helper\Category;
+
+class SpecialSymbolTestCest
+{
+    /** @var Category */
+    protected $category;
+
+    /** @var User */
+    protected $user;
+
+    /** @var Post */
+    protected $post;
+
+
+    protected function _inject(Category $category, User $user, Post $post)
+    {
+        $this->user     = $user;
+        $this->post     = $post;
+        $this->category = $category;
+    }
+
+    public function shouldFollowTheLink(AcceptanceTester $I)
+    {
+        $I->wantTo("Check special symbols in post's code tags");
+
+        $user  = $this->user->haveUser();
+        $catId = $this->category->haveCategory();
+
+        $content = "Should have <' `<h1>Code content < </h1> {{ partial('partials/listings') }} `";
+        $content .= "This is the content that's in the db right `Code again <' `";
+
+        $postId = $this->post->havePost([
+            'title'         => 'Test special symbols in post text',
+            'content'       => $content,
+            'slug'          => 'test_special_sumbol',
+            'users_id'      => $user['id'],
+            'categories_id' => $catId,
+        ]);
+
+        $I->amOnPage("/discussion/{$postId}/test_special_sumbol");
+        $I->seeInSource('Test special symbols in post text');
+
+        $I->seeInSource("{ partial('partials/listings') }");
+        $I->seeInSource("Should have &lt;'");
+        $I->seeInSource("Code again &lt;'");
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #40

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Fix special symbols in post text. `&#039;` instead of `'`

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md