### PR TITLE
Add support del and ins tags to post

### DIFF
--- a/app/provider/Markdown/Plugins/SpecSymbolExtension.php
+++ b/app/provider/Markdown/Plugins/SpecSymbolExtension.php
@@ -33,14 +33,17 @@ class SpecSymbolExtension implements ExtensionInterface
     public function escapeText(Text $text)
     {
         $replaceArray = [];
+        $arrTags = ['code', 'ins', 'del'];
 
-        $text->replace('{<code>.*?</code>}m', function (Text $w) use (&$replaceArray) {
-            $count = count($replaceArray) + 1;
-            $replaceArray[$count] = $w->getString();
-            $w->replaceString($w->getString(), "%%replaced" . $count . "%%");
+        foreach ($arrTags as $tag) {
+            $text->replace("{<{$tag}>.*?</{$tag}>}m", function (Text $w) use (&$replaceArray) {
+                $count = count($replaceArray) + 1;
+                $replaceArray[$count] = $w->getString();
+                $w->replaceString($w->getString(), "%%replaced" . $count . "%%");
 
-            return $w;
-        });
+                return $w;
+            });
+        }
 
         $str = htmlspecialchars($text->getString());
         foreach ($replaceArray as $key => $value) {

--- a/app/views/help/markdown.volt
+++ b/app/views/help/markdown.volt
@@ -205,4 +205,24 @@ This [link][id2] has title attribute.
 </pre>
 </p>
 
+    <p>
+        <h3>Markup of inserted text</h3>
+        The <code>ins</code> tag defines a text that has been inserted into a document.
+    </p>
+<p>
+<pre>
+My favorite color is <del>blue</del> <ins>red</ins>!
+</pre>
+</p>
+
+    <p>
+        <h3>Markup of deleted text</h3>
+        The <code>del</code> tag defines text that has been deleted from a document.
+    </p>
+<p>
+<pre>
+My favorite color is <del>blue</del> <ins>red</ins>!
+</pre>
+</p>
+
 </div>

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -416,7 +416,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   overflow: auto;
   -webkit-transition: left 0.2s ease;
   -moz-transition: left 0.2s ease;
-  -ms-transition: left 0.2s ease;
+  -o-transition: left 0.2s ease;
   transition: left 0.2s ease;
 }
 .editor-preview-active {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -997,3 +997,11 @@ div#sticky-progress {
     padding: .3rem 0;
     color: rgba(51, 51, 51, 0.8);
 }
+
+ins {
+    text-decoration: underline;
+}
+
+del {
+    text-decoration: line-through;
+}

--- a/tests/acceptance/SpecialSymbolTestCest.php
+++ b/tests/acceptance/SpecialSymbolTestCest.php
@@ -40,7 +40,7 @@ class SpecialSymbolTestCest
         $this->category = $category;
     }
 
-    public function shouldFollowTheLink(AcceptanceTester $I)
+    public function shouldHaveCodeSpecialSymbolInContent(AcceptanceTester $I)
     {
         $I->wantTo("Check special symbols in post's code tags");
 
@@ -64,5 +64,61 @@ class SpecialSymbolTestCest
         $I->seeInSource("{ partial('partials/listings') }");
         $I->seeInSource("Should have &lt;'");
         $I->seeInSource("Code again &lt;'");
+    }
+
+    public function shouldHaveAllSpecialSymbolsInContent(AcceptanceTester $I)
+    {
+        $I->wantTo("Check all special symbols in post's code tags");
+
+        $user  = $this->user->haveUser();
+        $catId = $this->category->haveCategory();
+
+        $content = "Should have <' `<h1>Code content < </h1> {{ partial('partials/listings') }}` is the content that's in the db";
+        $content .= "<ins>test ins1 tag</ins> right `test code2` <ins>test ins2 tag</ins> text <del>test del tag</del>";
+
+        $postId = $this->post->havePost([
+            'title'         => 'Test all special symbols in post text',
+            'content'       => $content,
+            'slug'          => 'test_all_special_sumbol',
+            'users_id'      => $user['id'],
+            'categories_id' => $catId,
+        ]);
+
+        $I->amOnPage("/discussion/{$postId}/test_all_special_sumbol");
+        $I->seeInSource('Test all special symbols in post text');
+
+        $I->seeInSource("{ partial('partials/listings') }");
+        $I->seeInSource("Should have &lt;'");
+        $I->seeInSource("<ins>test ins1 tag</ins>");
+        $I->seeInSource("right <code>test code2</code>");
+        $I->seeInSource("<ins>test ins2 tag</ins>");
+        $I->seeInSource("<del>test del tag</del>");
+    }
+
+    public function shouldHaveDelInsSpecialSymbolsInContent(AcceptanceTester $I)
+    {
+        $I->wantTo("Check del and ins tags in post's content");
+
+        $user  = $this->user->haveUser();
+        $catId = $this->category->haveCategory();
+
+        $content = "Should have <' <ins>test ins1 tag</ins> right ";
+        $content .= "<ins>test ins2 tag</ins> text <del>test del tag</del>";
+
+        $postId = $this->post->havePost([
+            'title'         => 'Test del and ins tags in post text',
+            'content'       => $content,
+            'slug'          => 'test_del_ins_tags',
+            'users_id'      => $user['id'],
+            'categories_id' => $catId,
+        ]);
+
+        $I->amOnPage("/discussion/{$postId}/test_all_special_sumbol");
+        $I->seeInSource('Test del and ins tags in post text');
+
+        $I->seeInSource("Should have &lt;'");
+        $I->seeInSource("<ins>test ins1 tag</ins>");
+        $I->seeInSource("<ins>test ins2 tag</ins>");
+        $I->seeInSource("<del>test del tag</del>");
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #51

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Added support `ins` and `del` tags to posts text

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md