### PR TITLE
Prevent to add amount of post view of post author

### DIFF
--- a/app/controller/DiscussionsController.php
+++ b/app/controller/DiscussionsController.php
@@ -592,16 +592,14 @@ class DiscussionsController extends ControllerBase
             ];
 
             // A view is stored by ip address
-            if (!$viewed = PostsViews::count($parameters)) {
+            if (PostsViews::count($parameters) == 0 && $post->users_id != $usersId) {
                 // Increase the number of views in the post
                 $post->number_views++;
-                if ($post->users_id != $usersId) {
-                    $post->user->increaseKarma(Karma::VISIT_ON_MY_POST);
+                $post->user->increaseKarma(Karma::VISIT_ON_MY_POST);
 
-                    if ($user = Users::findFirstById($usersId)) {
-                        $user->increaseKarma($user->moderator == 'Y' ? Karma::MODERATE_VISIT_POST : Karma::VISIT_POST);
-                        $user->save();
-                    }
+                if ($user = Users::findFirstById($usersId)) {
+                    $user->increaseKarma($user->moderator == 'Y' ? Karma::MODERATE_VISIT_POST : Karma::VISIT_POST);
+                    $user->save();
                 }
 
                 $postView            = new PostsViews();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Prevent to add post's view after creating of post

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md