### PR TITLE
Checking empty message in reply

### DIFF
--- a/app/controller/DiscussionsController.php
+++ b/app/controller/DiscussionsController.php
@@ -695,6 +695,10 @@ class DiscussionsController extends ControllerBase
 
                 $this->flash->error(join('<br>', $postReply->getMessages()));
             }
+
+            $this->flashSession->error("Reply message can't be empty");
+            $this->response->redirect("discussion/{$post->id}/{$post->slug}");
+            return;
         }
 
         $voting = [];


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
To prevent appear 500x error, when send empty reply message

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md