### PR TITLE
Prevent error when queue does not work

### DIFF
--- a/app/model/PostsReplies.php
+++ b/app/model/PostsReplies.php
@@ -232,15 +232,29 @@ class PostsReplies extends Model
             }
 
             /**
-             * Queue notifications to be sent
+             * Queue notifications to be sent.
+             *
+             * @var Beanstalk $queue
              */
-            /** @var Beanstalk $queue */
-            $queue = container('queue');
-            $queue->choose('notifications');
-            $queue->put($toNotify);
+            try {
+                $queue = container('queue');
+                $queue->choose('notifications');
+                $queue->put($toNotify);
+            } catch (\Exception $e) {
+                // Do nothing
+            } catch (\Throwable $e) {
+                // Do nothing
+            }
+
             /** @var DiscordComponent $discord */
-            $discord = container('discord');
-            $discord->addMessageAboutReply($this);
+            try {
+                $discord = container('discord');//var_dump($discord);die;
+                $discord->addMessageAboutReply($this);
+            } catch (\Exception $e) {
+                // Do nothing
+            } catch (\Throwable $e) {
+                // Do nothing
+            }
         }
     }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
To prevent appear 500x, when queue adapter doesn't work

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md