### PR TITLE
Change replies counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add pagination when category was selected [#371](https://github.com/phalcon/forum/issues/371)
 - Add changelog [#58](https://github.com/phalcon/forum/issues/58)
 
+### Changed
+- Change replies counter. Amount include posts's owner and visitors' replies [#50](https://github.com/phalcon/forum/issues/50)
+
 ## [3.x](CHANGELOG-3.md)
 ## [2.x](CHANGELOG-2.md)
 

--- a/app/controller/CategoriesController.php
+++ b/app/controller/CategoriesController.php
@@ -75,6 +75,13 @@ class CategoriesController extends ControllerBase
             ->where('p.categories_id = :cat_id: AND p.deleted = 0', ['cat_id' => $categoryId])
             ->orderBy('p.created_at DESC')
             ->offset((int)($currentPage - 1) * self::POSTS_IN_PAGE)
+            ->leftJoin('Phosphorum\Model\PostsReplies', 'p.id = rp.posts_id', 'rp')
+            ->groupBy('p.id')
+            ->columns([
+                'p.*',
+                'COUNT(rp.posts_id) AS count_replies',
+                'IFNULL(MAX(rp.modified_at), MAX(rp.created_at)) AS reply_time'
+            ])
             ->getQuery()
             ->execute();
 

--- a/app/views/partials/list-posts.volt
+++ b/app/views/partials/list-posts.volt
@@ -36,10 +36,17 @@
                 <th class="hidden-xs">Last Reply</th>
             </tr>
         {%- for post in posts -%}
+            {%- if (post.reply_time != null) -%}
+                {%- set post.p.modified_at = post.reply_time -%}
+            {%- endif -%}
+
+            {%- set post.p.number_replies = post.count_replies,
+                post = post.p,
+                row_class = "post-positive"
+            -%}
+
             {%- if (post.votes_up - post.votes_down) <= -3 -%}
                 {%- set row_class = "post-negative" -%}
-            {%- else -%}
-                {%- set row_class = "post-positive" -%}
             {%- endif -%}
             <tr class="{% if post.sticked == "Y" %}row-sticked{% endif %} {{ row_class }}" itemscope itemtype="http://schema.org/Question">
                 {%  if config.theme.use_topics_icon %}

--- a/tests/acceptance/RepliesCounterCest.php
+++ b/tests/acceptance/RepliesCounterCest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phosphorum                                                             |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2013-present Phalcon Team and contributors               |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+*/
+
+use Helper\Post;
+use Helper\User;
+use Helper\Category;
+
+class RepliesCounterCest
+{
+    /** @var Category */
+    protected $category;
+
+    /** @var User */
+    protected $user;
+
+    /** @var Post */
+    protected $post;
+
+    /** @var array */
+    protected $data = [];
+
+    protected function _inject(Category $category, User $user, Post $post)
+    {
+        $this->user     = $user;
+        $this->post     = $post;
+        $this->category = $category;
+    }
+
+    /**
+     * Tests replies counter on on `/` page
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2018-04-10
+     */
+    public function shouldShowRepliesCounterOnIndexPage(AcceptanceTester $I)
+    {
+        $I->wantTo("Check amount replies on index page");
+
+        $this->data['post_owner'] = $this->user->haveUser();
+        $this->data['user'] = $this->user->haveUser();
+        $this->data['catId']  = $this->category->haveCategory([
+            'slug' => 'reply_cat'
+        ]);
+
+        $this->data['postId'] = $this->post->havePost([
+            'title'         => 'Test replies counter',
+            'content'       => 'Test replies counter, conten on index page',
+            'slug'          => 'test_index_reply',
+            'users_id'      => $this->data['post_owner']['id'],
+            'categories_id' => $this->data['catId'],
+        ]);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->post->havePostReply([
+                'posts_id' => $this->data['postId'],
+                'users_id' => $i == 2 ? $this->data['user']['id'] : $this->data['post_owner']['id'],
+                'accepted' => 'N',
+                'content'  => 'Test replies counter, content reply on index page ' . $i,
+            ]);
+        }
+
+        $I->amOnPage('/');
+        $I->canSee('3', '//span/span');
+    }
+
+    /**
+     * Tests replies counter on on page with chosen category
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2018-04-10
+     */
+    public function shouldShowRepliesCounterOnCategoryPage(AcceptanceTester $I)
+    {
+        $I->wantTo("Check amount replies on category page");
+
+        $I->amOnPage('/category/'. $this->data['catId'] . '/reply_cat');
+        $I->canSee('3', '//span/span');
+    }
+
+    /**
+     * Tests replies counter on on post's page
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2018-04-10
+     */
+    public function shouldShowRepliesCounterOnPostPage(AcceptanceTester $I)
+    {
+        $I->wantTo("Check amount replies on post page");
+
+        $I->amOnPage('/discussion/' . $this->data['postId'] . '/test_index_reply');
+        $I->canSee('3', '//td/span');
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #50

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Change replies counter. Amount include posts's owner and visitors' replies.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md