### PR TITLE
Change default log path for error in config.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed log path for errors in config.php [#473](https://github.com/phalcon/forum/issues/473)
 
 ## [3.5.x](CHANGELOG-3.5.md)
 ## [3.x](CHANGELOG-3.md)

--- a/config/config.php
+++ b/config/config.php
@@ -79,7 +79,7 @@ return [
     ],
 
     'error' => [
-        'logger'    => app_path('logs/error.log'),
+        'logger'    => storage_path('logs/application.log'),
         'formatter' => [
             'format' => env('LOGGER_FORMAT', '[%date%][%type%] %message%'),
             'date'   => 'd-M-Y H:i:s',


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #473

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Change default log path for error in config.php

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md